### PR TITLE
Change source to . to make dev script work in Ubuntu

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "setup:install:server": "cd server && python3 -m venv env && source ./env/bin/activate && pip install -r requirements.txt && python -m unidic download && deactivate",
     "dev": "npm run server:dev & npm run web:dev",
     "web:dev": "cd web && npm run dev",
-    "server:dev": "cd server && source ./env/bin/activate && uvicorn main:app --reload --port 8000 && deactivate"
+    "server:dev": "cd server && . ./env/bin/activate && uvicorn main:app --reload --port 8000 && deactivate"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `source` を `.` とすることで Ubuntu で `dev` コマンドが動かないバグを直しました。