### PR TITLE
Fix error of deploy

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,7 +15,7 @@ services:
     plan: free
     rootDir: server
     buildCommand: pip install -r requirements.txt && python -m unidic download
-    startCommand: uvicorn main:app --port 10000
+    startCommand: uvicorn main:app --host 0.0.0.0 --port 10000
     envVars:
       - key: PORT
         value: 10000


### PR DESCRIPTION
- デプロイが壊れていたのを直しました。
  どうやら、Render ではホストを 0.0.0.0 にして、ポート番号を 10000 にしないと、動かないらしいです。これは、ドキュメント化すらされていないそうです:sob:
  https://community.render.com/t/fastapi-python-web-service-deploying-for-hours/6662